### PR TITLE
Selectively clear allocator bytes since most of them are immediately …

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"sync"
 
 	"log"
 	"syscall"
@@ -21,14 +20,14 @@ type Conn struct {
 	// after Ready is closed.
 	MountError error
 
-	// File handle for kernel communication. Only safe to access if
-	// rio or wio is held.
+	// File handle for kernel communication.
 	dev *os.File
-	wio sync.RWMutex
-	rio sync.RWMutex
 
 	// Protocol version negotiated with InitRequest/InitResponse.
 	proto Protocol
+
+	// Pointer to the config used to setup Conn.
+	conf *mountConfig
 }
 
 // Caller may pass this to Conn.Read() to have us take care of handling and responding.
@@ -81,6 +80,7 @@ func Mount(dir string, mem *Allocator, options ...MountOption) (*Conn, error) {
 	ready := make(chan struct{}, 1)
 	c := &Conn{
 		Ready: ready,
+		conf:  &conf,
 	}
 	f, err := mount(dir, &conf, ready, &c.MountError)
 	if err != nil {
@@ -165,16 +165,16 @@ func (malformedMessage) String() string {
 
 // Close closes the FUSE connection.
 func (c *Conn) Close() error {
-	c.wio.Lock()
-	defer c.wio.Unlock()
-	c.rio.Lock()
-	defer c.rio.Unlock()
-	return c.dev.Close()
+	err := syscall.Close(c.fd())
+	c.dev = nil
+	return err
 }
 
-// caller must hold wio or rio
 func (c *Conn) fd() int {
-	return int(c.dev.Fd())
+	if c.dev != nil {
+		return int(c.dev.Fd())
+	}
+	return -1
 }
 
 func (c *Conn) Protocol() Protocol {
@@ -182,8 +182,8 @@ func (c *Conn) Protocol() Protocol {
 }
 
 func (c *Conn) Read(alloc *Allocator, handler Servlet) (*RequestScope, error) {
-	scope := alloc.newRequest(c)
-	buf := alloc.alloc(bufSize)
+	scope := alloc.newRequest(c, false)
+	buf := alloc.alloc(bufSize, false)
 	n, err := c.read(buf)
 	if err != nil {
 		return nil, err
@@ -203,9 +203,10 @@ func (c *Conn) Read(alloc *Allocator, handler Servlet) (*RequestScope, error) {
 
 func (c *Conn) read(b []byte) (int, error) {
 	for {
-		c.rio.RLock()
 		n, err := syscall.Read(c.fd(), b)
-		c.rio.RUnlock()
+		if err != nil {
+			log.Println("read.err ", n, err)
+		}
 		if err == syscall.EINTR {
 			// OSXFUSE sends EINTR to userspace when a request interrupt
 			// completed before it got sent to userspace?
@@ -257,8 +258,6 @@ func (c *Conn) writeToKernel(msg []byte) error {
 	out := (*outHeader)(unsafe.Pointer(&msg[0]))
 	out.len = uint32(len(msg))
 
-	c.wio.RLock()
-	defer c.wio.RUnlock()
 	if Trace {
 		log.Print("fuse done")
 	}

--- a/fuse.go
+++ b/fuse.go
@@ -234,9 +234,9 @@ func processBuf(b []byte, scope *RequestScope, handler Servlet) (req Request, re
 		if req, resp, err = parseGetattr(b, scope.alloc, scope.conn.proto); handler != nil && err == nil {
 			handleErr = handler.HandleGetattr(req.(*GetattrRequest), resp.(*GetattrResponse))
 		}
-	case OpGetxattr, OpListxattr, OpFlush, OpForget:
+	case OpGetxattr, OpListxattr, OpFlush, OpForget, OpInterrupt, OpDestroy:
 		req, resp, err = parseUnsupported(b, scope.alloc)
-		handleErr = ENOTSUP
+		handleErr = ENOSYS
 	case OpLookup:
 		if req, resp, err = parseLookup(b, scope.alloc); handler != nil && err == nil {
 			handleErr = handler.HandleLookup(req.(*LookupRequest), resp.(*LookupResponse))

--- a/memory.go
+++ b/memory.go
@@ -26,17 +26,20 @@ func MakeAlloc() *Allocator {
 	return &Allocator{buf: make([]byte, memSize)}
 }
 
-func (a *Allocator) newRequest(c *Conn) *RequestScope {
-	a.reset()
+func (a *Allocator) newRequest(c *Conn, zeroed bool) *RequestScope {
 
-	scope := requestScope(a)
+	a.reset(zeroed)
+
+	scope := requestScope(a, false)
 	scope.alloc = a
 	scope.conn = c
+	scope.Req = nil
+	scope.Resp = nil
 	return scope
 }
 
-func requestScope(a *Allocator) *RequestScope {
-	return (*RequestScope)(a.allocPointer(requestScopeSize))
+func requestScope(a *Allocator, zeroed bool) *RequestScope {
+	return (*RequestScope)(a.allocPointer(requestScopeSize, zeroed))
 }
 
 type Allocator struct {
@@ -44,18 +47,23 @@ type Allocator struct {
 	next int
 }
 
-func (a *Allocator) alloc(size uintptr) []byte {
+func (a *Allocator) alloc(size uintptr, zeroed bool) []byte {
 	s := int(size)
 	if a.next+s > cap(a.buf) {
 		panic(fmt.Sprintf("Not enough capacity: %v + %v > %v", a.next, size, cap(a.buf)))
 	}
 	r := a.buf[a.next : a.next+s]
 	a.next += s
+	if zeroed {
+		for ii := 0; ii < len(r); ii++ {
+			r[ii] = 0
+		}
+	}
 	return r
 }
 
-func (a *Allocator) allocPointer(size uintptr) unsafe.Pointer {
-	return unsafe.Pointer(&a.alloc(size)[0])
+func (a *Allocator) allocPointer(size uintptr, zeroed bool) unsafe.Pointer {
+	return unsafe.Pointer(&a.alloc(size, zeroed)[0])
 }
 
 func (a *Allocator) free(size int) {
@@ -65,10 +73,12 @@ func (a *Allocator) free(size int) {
 	}
 }
 
-func (a *Allocator) reset() {
-	b := a.buf[0:a.next]
-	for idx := range b {
-		b[idx] = 0
+func (a *Allocator) reset(zeroed bool) {
+	if zeroed {
+		b := a.buf[0:a.next]
+		for idx := range b {
+			b[idx] = 0
+		}
 	}
 	a.next = 0
 }

--- a/memory.go
+++ b/memory.go
@@ -26,6 +26,10 @@ func MakeAlloc() *Allocator {
 	return &Allocator{buf: make([]byte, memSize)}
 }
 
+// Note, the allocator funcs take a zeroed flag as an optimization.
+// Set zeroed to true if relying on struct/array default values when casting from bytes.
+// Set to false if bytes are immediately overwritten by the caller making zeroing superfluous.
+
 func (a *Allocator) newRequest(c *Conn, zeroed bool) *RequestScope {
 
 	a.reset(zeroed)

--- a/options.go
+++ b/options.go
@@ -15,6 +15,7 @@ type mountConfig struct {
 	options          map[string]string
 	maxReadahead     uint32
 	initFlags        InitFlags
+	threadUnsafe     bool
 	osxfuseLocations []OSXFUSEPaths
 }
 
@@ -156,6 +157,15 @@ func MaxReadahead(n uint32) MountOption {
 func AsyncRead() MountOption {
 	return func(conf *mountConfig) error {
 		conf.initFlags |= InitAsyncRead
+		return nil
+	}
+}
+
+// False means Conn will protect against concurrent reads. True means
+// that the calling code is single threaded and no locking is needed.
+func ThreadUnsafe(threadUnsafe bool) MountOption {
+	return func(conf *mountConfig) error {
+		conf.threadUnsafe = threadUnsafe
 		return nil
 	}
 }

--- a/reqs_dir.go
+++ b/reqs_dir.go
@@ -95,6 +95,8 @@ const readdirResponseHeaderStart = unsafe.Offsetof(ReaddirResponse{}.outHeader)
 const readdirResponseSize = unsafe.Sizeof(ReaddirResponse{})
 
 func readdirResponse(a *Allocator, dataSize uint32) *ReaddirResponse {
+	// Note, bytes are not zeroed by the allocator since we only want to zero the base struct.
+	// The remaining data bytes do not need to be zeroed, they're immediately overwritten by the caller.
 	bytes := a.alloc(readdirResponseBaseSize+uintptr(dataSize), false)
 	for ii := 0; ii < int(readdirResponseBaseSize); ii++ {
 		bytes[ii] = 0

--- a/reqs_dir.go
+++ b/reqs_dir.go
@@ -31,7 +31,7 @@ func (r *OpendirResponse) Flags(flags OpenResponseFlags) {
 const opendirResponseSize = unsafe.Sizeof(OpendirResponse{})
 
 func opendirResponse(a *Allocator) *OpendirResponse {
-	return (*OpendirResponse)(a.allocPointer(opendirResponseSize))
+	return (*OpendirResponse)(a.allocPointer(opendirResponseSize, true))
 }
 
 func (r *OpendirResponse) Respond(s *RequestScope) {
@@ -95,7 +95,11 @@ const readdirResponseHeaderStart = unsafe.Offsetof(ReaddirResponse{}.outHeader)
 const readdirResponseSize = unsafe.Sizeof(ReaddirResponse{})
 
 func readdirResponse(a *Allocator, dataSize uint32) *ReaddirResponse {
-	return (*ReaddirResponse)(a.allocPointer(readdirResponseBaseSize + uintptr(dataSize)))
+	bytes := a.alloc(readdirResponseBaseSize+uintptr(dataSize), false)
+	for ii := 0; ii < int(readdirResponseBaseSize); ii++ {
+		bytes[ii] = 0
+	}
+	return (*ReaddirResponse)(unsafe.Pointer(&bytes[0]))
 }
 
 func (r *ReaddirResponse) Respond(s *RequestScope) {
@@ -143,7 +147,7 @@ const releasedirRequestSize = unsafe.Sizeof(ReleasedirRequest{})
 const releasedirResponseSize = unsafe.Sizeof(ReleasedirResponse{})
 
 func releasedirResponse(a *Allocator) *ReleasedirResponse {
-	return (*ReleasedirResponse)(a.allocPointer(releasedirResponseSize))
+	return (*ReleasedirResponse)(a.allocPointer(releasedirResponseSize, true))
 }
 
 func (r *ReleasedirResponse) Respond(s *RequestScope) {

--- a/reqs_file.go
+++ b/reqs_file.go
@@ -92,6 +92,8 @@ const readResponseHeaderStart = unsafe.Offsetof(ReadResponse{}.outHeader)
 const readResponseSize = unsafe.Sizeof(ReadResponse{})
 
 func readResponse(a *Allocator, dataSize uint32) *ReadResponse {
+	// Note, bytes are not zeroed by the allocator since we only want to zero the base struct.
+	// The remaining data bytes do not need to be zeroed, they're immediately overwritten by the caller.
 	bytes := a.alloc(readResponseBaseSize+uintptr(dataSize), false)
 	for ii := 0; ii < int(readResponseBaseSize); ii++ {
 		bytes[ii] = 0

--- a/reqs_file.go
+++ b/reqs_file.go
@@ -27,7 +27,7 @@ func (r *OpenResponse) Flags(flags OpenResponseFlags) {
 const openResponseSize = unsafe.Sizeof(OpenResponse{})
 
 func openResponse(a *Allocator) *OpenResponse {
-	return (*OpenResponse)(a.allocPointer(openResponseSize))
+	return (*OpenResponse)(a.allocPointer(openResponseSize, true))
 }
 
 func (r *OpenResponse) Respond(s *RequestScope) {
@@ -92,7 +92,11 @@ const readResponseHeaderStart = unsafe.Offsetof(ReadResponse{}.outHeader)
 const readResponseSize = unsafe.Sizeof(ReadResponse{})
 
 func readResponse(a *Allocator, dataSize uint32) *ReadResponse {
-	return (*ReadResponse)(a.allocPointer(readResponseBaseSize + uintptr(dataSize)))
+	bytes := a.alloc(readResponseBaseSize+uintptr(dataSize), false)
+	for ii := 0; ii < int(readResponseBaseSize); ii++ {
+		bytes[ii] = 0
+	}
+	return (*ReadResponse)(unsafe.Pointer(&bytes[0]))
 }
 
 func (r *ReadResponse) Respond(s *RequestScope) {
@@ -140,7 +144,7 @@ const releaseRequestSize = unsafe.Sizeof(ReleaseRequest{})
 const releaseResponseSize = unsafe.Sizeof(ReleaseResponse{})
 
 func releaseResponse(a *Allocator) *ReleaseResponse {
-	return (*ReleaseResponse)(a.allocPointer(releaseResponseSize))
+	return (*ReleaseResponse)(a.allocPointer(releaseResponseSize, true))
 }
 
 func (r *ReleaseResponse) Respond(s *RequestScope) {

--- a/reqs_fs.go
+++ b/reqs_fs.go
@@ -56,7 +56,7 @@ func (r *initResponse) MaxWrite(max uint32) {
 }
 
 func newInitResponse(a *Allocator) *initResponse {
-	return (*initResponse)(a.allocPointer(initResponseSize))
+	return (*initResponse)(a.allocPointer(initResponseSize, true))
 }
 
 func (r *initResponse) Respond(s *RequestScope) {
@@ -76,7 +76,7 @@ func parseInit(b []byte, alloc *Allocator) (*initRequest, *initResponse, error) 
 }
 
 func statfsResponse(a *Allocator) *StatfsResponse {
-	return (*StatfsResponse)(a.allocPointer(statfsResponseSize))
+	return (*StatfsResponse)(a.allocPointer(statfsResponseSize, true))
 }
 
 func parseStatfs(b []byte, alloc *Allocator) (*StatfsRequest, *StatfsResponse, error) {
@@ -119,7 +119,7 @@ type UnsupportedResponse struct {
 const unsupportedResponseSize = unsafe.Sizeof(UnsupportedResponse{})
 
 func unsupportedResponse(a *Allocator) *UnsupportedResponse {
-	return (*UnsupportedResponse)(a.allocPointer(unsupportedResponseSize))
+	return (*UnsupportedResponse)(a.allocPointer(unsupportedResponseSize, true))
 }
 
 func parseUnsupported(b []byte, alloc *Allocator) (*UnsupportedRequest, *UnsupportedResponse, error) {

--- a/reqs_node.go
+++ b/reqs_node.go
@@ -55,7 +55,7 @@ func (r *GetattrResponse) Attr(attr Attr) {
 }
 
 func getattrResponse(a *Allocator) *GetattrResponse {
-	return (*GetattrResponse)(a.allocPointer(getattrResponseSize))
+	return (*GetattrResponse)(a.allocPointer(getattrResponseSize, true))
 }
 
 func parseGetattr(b []byte, alloc *Allocator, proto Protocol) (*GetattrRequest, *GetattrResponse, error) {
@@ -65,7 +65,7 @@ func parseGetattr(b []byte, alloc *Allocator, proto Protocol) (*GetattrRequest, 
 		// the buffer can't hold the entire GetattrRequest object.
 		// alloc extra memory to reserve it (even though we're just going to leave it
 		// zero'ed out)
-		alloc.alloc(getattrRequestSize - inHeaderSize)
+		alloc.alloc(getattrRequestSize-inHeaderSize, true)
 	} else {
 		if len(b) < int(getattrRequestSize) {
 			return nil, nil, corrupt(b, getattrRequestSize)
@@ -85,7 +85,7 @@ type LookupRequest struct {
 const lookupResponseSize = unsafe.Sizeof(LookupResponse{})
 
 func lookupResponse(a *Allocator) *LookupResponse {
-	return (*LookupResponse)(a.allocPointer(lookupResponseSize))
+	return (*LookupResponse)(a.allocPointer(lookupResponseSize, true))
 }
 
 func (r *LookupResponse) NodeID(nodeID NodeID) {
@@ -158,7 +158,7 @@ const readlinkResponseHeaderStart = unsafe.Offsetof(ReadlinkResponse{}.outHeader
 const readlinkResponseBaseSize = unsafe.Offsetof(ReadlinkResponse{}.data)
 
 func readlinkResponse(a *Allocator) *ReadlinkResponse {
-	return (*ReadlinkResponse)(a.allocPointer(readlinkResponseSize))
+	return (*ReadlinkResponse)(a.allocPointer(readlinkResponseSize, true))
 }
 
 func (r *ReadlinkResponse) Respond(s *RequestScope) {


### PR DESCRIPTION
…overridden. Added ThreadUnsafe mount option to control locking (not used yet). Removed all locking, it doesn't appear necessary on our supported platforms, second opinion needed though. Added some additional ops to the unsupported list.
